### PR TITLE
Use Market struct instead of CountryCode for get_artist_albums

### DIFF
--- a/src/endpoints/artists.rs
+++ b/src/endpoints/artists.rs
@@ -2,7 +2,6 @@
 
 use std::fmt::Display;
 
-use isocountry::CountryCode;
 use itertools::Itertools;
 use serde::Deserialize;
 
@@ -68,7 +67,7 @@ impl Artists<'_> {
         include_groups: Option<&[AlbumGroup]>,
         limit: usize,
         offset: usize,
-        country: Option<CountryCode>,
+        market: Option<Market>,
     ) -> Result<Response<Page<ArtistsAlbum>>, Error> {
         self.0
             .send_json(
@@ -84,7 +83,7 @@ impl Artists<'_> {
                                 groups.iter().map(|group| group.as_str()).join(","),
                             )
                         }),
-                        country.map(|c| ("country", c.alpha2())),
+                        market.map(Market::query),
                     )),
             )
             .await

--- a/src/endpoints/artists.rs
+++ b/src/endpoints/artists.rs
@@ -67,7 +67,7 @@ impl Artists<'_> {
         include_groups: Option<&[AlbumGroup]>,
         limit: usize,
         offset: usize,
-        market: Option<Market>,
+        country: Option<Market>,
     ) -> Result<Response<Page<ArtistsAlbum>>, Error> {
         self.0
             .send_json(
@@ -83,7 +83,7 @@ impl Artists<'_> {
                                 groups.iter().map(|group| group.as_str()).join(","),
                             )
                         }),
-                        market.map(Market::query),
+                        country.map(|m| ("country", m.as_str())),
                     )),
             )
             .await


### PR DESCRIPTION
As per the docs, the endpoint should support `from_token` as well:

https://developer.spotify.com/documentation/web-api/reference/artists/get-artists-albums/