### PR TITLE
Keep the refresh token in cache

### DIFF
--- a/examples/get_artist.rs
+++ b/examples/get_artist.rs
@@ -1,0 +1,23 @@
+use aspotify::{Client, ClientCredentials};
+
+#[tokio::main]
+async fn main() {
+    // Read the client credentials from the .env file
+    dotenv::dotenv().unwrap();
+
+    // Make the Spotify client using client credentials flow
+    let client = Client::new(ClientCredentials::from_env().unwrap());
+
+    // Call the Spotify API to get information on an artist
+    let artist = client
+        .artists()
+        .get_artist("2WX2uTcsvV5OnS0inACecP")
+        .await
+        .unwrap()
+        .data;
+
+    println!(
+        "Found artist named {} with {} followers",
+        artist.name, artist.followers.total
+    );
+}


### PR DESCRIPTION
When using the Authorization code flow (manually provided refresh_token), calling `Client.access_token` will remove the refresh token from the cache, meaning it cannot be used to retrieve another access token after that one expired.

I think the issue also rises after 2 hours if we go through `Client.redirected` (not providing a token, asking for user action): we'll be able to refresh the access token once, but not twice (the first refresh will clear out the refresh_token from the cache).

This PR holds the following changes:

- Add get_artist example to make sure I didn't break the client credentials flow
- Add a `TokenRequest` enum to materialize the request body more expressively than tuples
- Fix `access_token` to re-inject an existing refresh_token value if the response does not have one

I am pretty new to Rust, please nitpick what you'd like to adjust.